### PR TITLE
Update pidlockfile.py

### DIFF
--- a/daemon/pidlockfile.py
+++ b/daemon/pidlockfile.py
@@ -17,10 +17,10 @@ import os
 import errno
 
 from lockfile import (
-    LinkFileLock,
     AlreadyLocked, LockFailed,
     NotLocked, NotMyLock,
     )
+from lockfile.linklockfile import LinkLockFile
 
 
 class PIDFileError(Exception):
@@ -30,7 +30,7 @@ class PIDFileParseError(ValueError, PIDFileError):
     """ Raised when parsing contents of PID file fails. """
 
 
-class PIDLockFile(LinkFileLock, object):
+class PIDLockFile(LinkLockFile, object):
     """ Lockfile implemented as a Unix PID file.
 
         The PID file is named by the attribute `path`. When locked,
@@ -38,7 +38,7 @@ class PIDLockFile(LinkFileLock, object):
         containing the process ID (PID) of the process that acquired
         the lock.
 
-        The lock is acquired and maintained as per `LinkFileLock`.
+        The lock is acquired and maintained as per `LinkLockFile`.
 
         """
 
@@ -53,7 +53,7 @@ class PIDLockFile(LinkFileLock, object):
 
             Locks the PID file then creates the PID file for this
             lock. The `timeout` parameter is used as for the
-            `LinkFileLock` class.
+            `LinkLockFile` class.
 
             """
         super(PIDLockFile, self).acquire(*args, **kwargs)


### PR DESCRIPTION
LinkFileLock is deprecated. Instead, import LinkLockFile from the lockfile.linklockfile module.
